### PR TITLE
Make fails because stamps directory does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-all:  cpp-minimal python-minimal
+all:  stamps cpp-minimal python-minimal
+
+stamps:
+	mkdir -p stamps
 
 stamps/cppdeps.stamp: gnuradio-cppdeps/Dockerfile
 	docker build -f gnuradio-cppdeps/Dockerfile -t gnuradio/gnuradio-cppdeps gnuradio-cppdeps


### PR DESCRIPTION
The touch command requires that the stamps directory exists, but after an initial clone of this repository, it doesn't. This change creates the stamps directory if needed.