### PR TITLE
feature: gr-iio

### DIFF
--- a/ci/ci-centos-8.3-3.9/Dockerfile
+++ b/ci/ci-centos-8.3-3.9/Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:8.3.2011
-MAINTAINER Martin Braun <martin@gnuradio.org>
+LABEL maintainer="martin@gnuradio.org"
 
 ENV security_updates_as_of 2021-01-06
 
@@ -7,7 +7,9 @@ RUN dnf install epel-release -y -q
 RUN dnf -y install dnf-plugins-core
 RUN dnf --enablerepo=epel check-update -y; dnf install -y \
 # Build
+        bison \
         cmake3 \
+        flex \
         make \
         gcc \
         gcc-c++ \
@@ -42,7 +44,10 @@ RUN dnf install -y \
         uhd-devel \
 ## Vocoder libraries
         codec2-devel \
-        gsm-devel
+        gsm-devel \
+# gr-iio
+        libusb-devel \
+        libxml2-devel
 
 # Python deps
 RUN dnf install -y \
@@ -82,4 +87,15 @@ RUN dnf clean all
 RUN mkdir -p /src/build
 RUN git clone --recursive https://github.com/gnuradio/volk.git /src/volk --branch v2.4.1 --depth 1
 RUN cd /src/build && cmake -DCMAKE_BUILD_TYPE=Release ../volk/ && make && make install && cd / && rm -rf /src/
+
+# Install libiio
+RUN mkdir -p /src/build
+RUN git clone --recursive https://github.com/analogdevicesinc/libiio.git /src/libiio --branch 2019_R2 --depth 1
+RUN cd /src/build && cmake -DCMAKE_BUILD_TYPE=Release ../libiio/ && make && make install && cd / && rm -rf /src/
+
+# Install libiio-ad9361
+RUN mkdir -p /src/build
+RUN git clone --recursive https://github.com/analogdevicesinc/libad9361-iio.git /src/libiio_ad9361 --branch 2019_R2 --depth 1
+RUN cd /src/build && cmake -DCMAKE_BUILD_TYPE=Release ../libiio_ad9361/ && make && make install && cd / && rm -rf /src/
+
 RUN pip3 install --upgrade mako

--- a/ci/ci-debian-10-3.9/Dockerfile
+++ b/ci/ci-debian-10-3.9/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:buster
-MAINTAINER Martin Braun <martin@gnuradio.org>
+LABEL maintainer="martin@gnuradio.org"
 
 ENV security_updates_as_of 2021-01-06
 
@@ -10,6 +10,7 @@ RUN apt-get update -q \
 # CPP deps
 RUN DEBIAN_FRONTEND=noninteractive \
        apt-get install -qy \
+         libad9361-0 \
          libasound2 \
          libboost-date-time1.67.0 \
          libboost-filesystem1.67.0 \
@@ -20,6 +21,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
          libgmp10 \
          libgsl23 \
          libgtk-3-0 \
+         libiio0 \
          libjack-jackd2-0 \
          liblog4cpp5v5 \
          libpangocairo-1.0-0 \
@@ -65,6 +67,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
        build-essential \
        ccache \
        cmake \
+       libad9361-dev \
        libboost-date-time-dev \
        libboost-dev \
        libboost-filesystem-dev \
@@ -78,6 +81,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
        libfftw3-dev \
        libgmp-dev \
        libgsl0-dev \
+       libiio-dev \
        liblog4cpp5-dev \
        libqwt-qt5-dev \
        qtbase5-dev \

--- a/ci/ci-fedora-33-3.9/Dockerfile
+++ b/ci/ci-fedora-33-3.9/Dockerfile
@@ -1,5 +1,5 @@
 FROM fedora:33
-MAINTAINER Martin Braun <martin@gnuradio.org>
+LABEL maintainer="martin@gnuradio.org"
 
 ENV security_updates_as_of 2021-01-06
 
@@ -36,7 +36,10 @@ RUN dnf install -y \
         uhd-devel \
 ## Vocoder libraries
         codec2-devel \
-        gsm-devel
+        gsm-devel \
+# gr-iio
+        libad9361-devel \
+        libiio-devel
 
 # Python deps
 RUN dnf install -y \

--- a/ci/ci-ubuntu-18.04-3.8/Dockerfile
+++ b/ci/ci-ubuntu-18.04-3.8/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-MAINTAINER Martin Braun <martin@gnuradio.org>
+LABEL maintainer="martin@gnuradio.org"
 
 ENV security_updates_as_of 2021-01-13
 
@@ -10,6 +10,7 @@ RUN apt-get update -q \
 # CPP deps
 RUN DEBIAN_FRONTEND=noninteractive \
        apt-get install -qy \
+         libad9361-0 \
          libasound2 \
          libboost-date-time1.65.1 \
          libboost-filesystem1.65.1 \
@@ -20,6 +21,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
          libgmp10 \
          libgsl23 \
          libgtk-3-0 \
+         libiio0 \
          libjack-jackd2-0 \
          liblog4cpp5v5 \
          libpangocairo-1.0-0 \
@@ -86,6 +88,7 @@ RUN mv /sbin/sysctl /sbin/sysctl.orig \
        build-essential \
        ccache \
        cmake \
+       libad9361-dev \
        libboost-date-time-dev \
        libboost-dev \
        libboost-filesystem-dev \
@@ -99,6 +102,7 @@ RUN mv /sbin/sysctl /sbin/sysctl.orig \
        libfftw3-dev \
        libgmp-dev \
        libgsl0-dev \
+       libiio-dev \
        liblog4cpp5-dev \
        libqt4-dev \
        libqwt-dev \

--- a/ci/ci-ubuntu-18.04-3.9/Dockerfile
+++ b/ci/ci-ubuntu-18.04-3.9/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-MAINTAINER Martin Braun <martin@gnuradio.org>
+LABEL maintainer="martin@gnuradio.org"
 
 ENV security_updates_as_of 2020-12-18
 
@@ -10,6 +10,7 @@ RUN apt-get update -q \
 # CPP deps
 RUN DEBIAN_FRONTEND=noninteractive \
        apt-get install -qy \
+         libad9361-0 \
          libasound2 \
          libboost-date-time1.65.1 \
          libboost-filesystem1.65.1 \
@@ -20,6 +21,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
          libgmp10 \
          libgsl23 \
          libgtk-3-0 \
+         libiio0 \
          libjack-jackd2-0 \
          liblog4cpp5v5 \
          libpangocairo-1.0-0 \
@@ -68,6 +70,7 @@ RUN mv /sbin/sysctl /sbin/sysctl.orig \
        build-essential \
        ccache \
        cmake \
+       libad9361-dev \
        libboost-date-time-dev \
        libboost-dev \
        libboost-filesystem-dev \
@@ -81,6 +84,7 @@ RUN mv /sbin/sysctl /sbin/sysctl.orig \
        libfftw3-dev \
        libgmp-dev \
        libgsl0-dev \
+       libiio-dev \
        liblog4cpp5-dev \
        libqt4-dev \
        libqwt-dev \

--- a/ci/ci-ubuntu-20.04-3.9/Dockerfile
+++ b/ci/ci-ubuntu-20.04-3.9/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:20.04
-MAINTAINER Martin Braun <martin@gnuradio.org>
+LABEL maintainer="martin@gnuradio.org"
 
 ENV security_updates_as_of 2020-12-18
 
@@ -10,6 +10,7 @@ RUN apt-get update -q \
 # CPP deps
 RUN DEBIAN_FRONTEND=noninteractive \
        apt-get install -qy \
+         libad9361-0 \
          libasound2 \
          libboost-date-time1.71.0 \
          libboost-filesystem1.71.0 \
@@ -20,6 +21,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
          libgmp10 \
          libgsl23 \
          libgtk-3-0 \
+         libiio0 \
          libjack-jackd2-0 \
          liblog4cpp5v5 \
          libpangocairo-1.0-0 \
@@ -67,6 +69,7 @@ RUN mv /sbin/sysctl /sbin/sysctl.orig \
        build-essential \
        ccache \
        cmake \
+       libad9361-dev \
        libboost-date-time-dev \
        libboost-dev \
        libboost-filesystem-dev \
@@ -80,6 +83,7 @@ RUN mv /sbin/sysctl /sbin/sysctl.orig \
        libfftw3-dev \
        libgmp-dev \
        libgsl0-dev \
+       libiio-dev \
        liblog4cpp5-dev \
        libqwt-qt5-dev \
        qtbase5-dev \


### PR DESCRIPTION
# **feature:** iio

This pull request is related to GNU Radio Enhancement Proposals 0017. In short it adds the gr-iio out of tree module in tree.
This allows CI to have the required dependencies as required to build `gr-iio`.

## **Refactoring**

We have also refactored the various Docker containers to remove the legacy `MAINTAINER` syntax.

Please see:

https://docs.docker.com/engine/reference/builder/

Signed-off-by: Adam Horden <adam.horden@horden.engineering>