### PR TITLE
ci: Remove comedi from 3.9 CI images

### DIFF
--- a/ci/ci-debian-10-3.9/Dockerfile
+++ b/ci/ci-debian-10-3.9/Dockerfile
@@ -75,7 +75,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
        libboost-system-dev \
        libboost-test-dev \
        libboost-thread-dev \
-       libcomedi-dev \
        libcppunit-dev \
        libfftw3-dev \
        libgmp-dev \

--- a/ci/ci-ubuntu-18.04-3.9/Dockerfile
+++ b/ci/ci-ubuntu-18.04-3.9/Dockerfile
@@ -16,7 +16,6 @@ RUN DEBIAN_FRONTEND=noninteractive \
          libboost-filesystem1.65.1 \
          libboost-program-options1.65.1 \
          libboost-thread1.65.1 \
-         libcomedi0 \
          libfftw3-bin \
          libgmp10 \
          libgsl23 \
@@ -80,7 +79,6 @@ RUN mv /sbin/sysctl /sbin/sysctl.orig \
        libboost-system-dev \
        libboost-test-dev \
        libboost-thread-dev \
-       libcomedi-dev \
        libcppunit-dev \
        libfftw3-dev \
        libgmp-dev \

--- a/ci/ci-ubuntu-20.04-3.9/Dockerfile
+++ b/ci/ci-ubuntu-20.04-3.9/Dockerfile
@@ -16,7 +16,6 @@ RUN DEBIAN_FRONTEND=noninteractive \
          libboost-filesystem1.71.0 \
          libboost-program-options1.71.0 \
          libboost-thread1.71.0 \
-         libcomedi0 \
          libfftw3-bin \
          libgmp10 \
          libgsl23 \
@@ -81,7 +80,6 @@ RUN mv /sbin/sysctl /sbin/sysctl.orig \
        libboost-system-dev \
        libboost-test-dev \
        libboost-thread-dev \
-       libcomedi-dev \
        libcppunit-dev \
        libfftw3-dev \
        libgmp-dev \


### PR DESCRIPTION
GNU Radio 3.9 does not support comedi any more.

Fixes https://github.com/gnuradio/gnuradio-docker/issues/9