### PR TITLE
Add Debian 10, CentOS 8.4 for GR 3.10

### DIFF
--- a/.github/workflows/build-dockers.yml
+++ b/.github/workflows/build-dockers.yml
@@ -30,6 +30,8 @@ jobs:
             tag: centos-7.6-3.9
           - path: ci/ci-centos-8.3-3.9
             tag: centos-8.3-3.9
+          - path: ci/ci-centos-8.4-3.10
+            tag: centos-8.4-3.10
           - path: ci/ci-debian-10-3.9
             tag: debian-10-3.9
           - path: ci/ci-debian-11-3.10

--- a/.github/workflows/build-dockers.yml
+++ b/.github/workflows/build-dockers.yml
@@ -34,6 +34,8 @@ jobs:
             tag: centos-8.4-3.10
           - path: ci/ci-debian-10-3.9
             tag: debian-10-3.9
+          - path: ci/ci-debian-10-3.10
+            tag: debian-10-3.10
           - path: ci/ci-debian-11-3.10
             tag: debian-11-3.10
           - path: ci/ci-fedora-33-3.9

--- a/ci/ci-centos-8.4-3.10/Dockerfile
+++ b/ci/ci-centos-8.4-3.10/Dockerfile
@@ -1,0 +1,127 @@
+FROM centos:8.4.2105
+LABEL maintainer="martin@gnuradio.org"
+
+ENV security_updates_as_of 2021-11-01
+
+RUN dnf install epel-release -y -q && \
+    dnf -y install dnf-plugins-core && \
+    dnf --enablerepo=epel check-update -y ;\
+    dnf install -y \
+# Build
+    cmake3 \
+# cmake bug requires this to be installed:
+    libarchive \
+    make \
+    gcc \
+    gcc-c++ \
+    xz \
+    ccache \
+    clang && \
+    dnf config-manager --set-enabled powertools && \
+# CPP deps
+    dnf install -y \
+    boost169-devel \
+    log4cpp-devel \
+    cppzmq-devel \
+    libunwind-devel \
+    fmt-devel \
+    spdlog-devel \
+# ctrlport - thrift
+    thrift \
+    thrift-devel \
+# Math libraries
+    fftw-devel \
+    gsl-devel \
+    gmp-devel \
+# Documentation
+    doxygen \
+    graphviz \
+# Audio, SDL
+    SDL-devel \
+    alsa-lib-devel \
+    portaudio-devel \
+    jack-audio-connection-kit-devel \
+    libsndfile-devel \
+# HW drivers
+    uhd-devel \
+## Vocoder libraries
+    codec2-devel \
+    gsm-devel \
+# gr-iio
+    libusb-devel \
+    libxml2-devel \
+# Python deps
+    python3-devel \
+    python3-pybind11 \
+    python3-numpy \
+    python3-scipy \
+    python3-zmq \
+    python3-thrift \
+    python3-pytest \
+    python3-PyYAML \
+# GUI libraries
+    xdg-utils \
+    qwt-qt5-devel \
+    python3-PyQt5 \
+    python3-qt5-devel \
+# XML Parsing / GRC
+    desktop-file-utils \
+    python3-mako \
+    python3-click \
+    python3-click-plugins \
+# GRC/next
+    python3-pyyaml \
+    python3-lxml \
+    python3-gobject \
+    gtk3 \
+    python3-cairo \
+    pango \
+# For VOLK
+    git && \
+    dnf clean all && \
+    pip3 install --upgrade mako
+
+# Install VOLK
+RUN mkdir -p /src/build && \
+    git clone --recursive https://github.com/gnuradio/volk.git /src/volk --branch v2.4.1 --depth 1 && \
+    cd /src/build && \
+    cmake -DCMAKE_BUILD_TYPE=Release ../volk/ && \
+    make && \
+    make install && \
+    cd / && \
+    rm -rf /src/
+
+# Install libiio
+RUN dnf install -y flex bison && \
+    dnf clean all && \
+    mkdir -p /src/build && \
+    git clone --recursive https://github.com/analogdevicesinc/libiio.git /src/libiio --branch 2019_R2 --depth 1 && \
+    cd /src/build && \
+    cmake -DCMAKE_BUILD_TYPE=Release ../libiio/ && \
+    make && \
+    make install && \
+    cd / && \
+    rm -rf /src/
+
+# Install libiio-ad9361
+RUN mkdir -p /src/build && \
+    git clone --recursive https://github.com/analogdevicesinc/libad9361-iio.git /src/libiio_ad9361 --branch 2019_R2 --depth 1 && \
+    cd /src/build && \
+    cmake -DCMAKE_BUILD_TYPE=Release ../libiio_ad9361/ && \
+    make && \
+    make install && \
+    cd / && \
+    rm -rf /src/
+
+# Install SoapySDR
+RUN mkdir -p /src \
+    && pushd /src \
+    && git clone -b soapy-sdr-0.8.0 https://github.com/pothosware/SoapySDR/ \
+    && cd SoapySDR \
+    && mkdir build \
+    && cd build \
+    && cmake -DCMAKE_INSTALL_PREFIX=/usr .. \
+    && make install \
+    && popd \
+    && rm -rf /src
+

--- a/ci/ci-debian-10-3.10/Dockerfile
+++ b/ci/ci-debian-10-3.10/Dockerfile
@@ -1,0 +1,121 @@
+FROM debian:buster
+LABEL maintainer="martin@gnuradio.org"
+
+ENV security_updates_as_of 2021-11-01
+
+# Prepare distribution
+RUN apt-get update -q \
+    && apt-get -y upgrade \
+    && apt-get install -qy \
+    ca-certificates \
+    && sh -c 'echo deb http://deb.debian.org/debian buster-backports main > /etc/apt/sources.list.d/backports.list' \
+    && apt-get clean
+
+# CPP deps
+RUN DEBIAN_FRONTEND=noninteractive \
+    && apt-get update \
+    && apt-get install -qy \
+    git \
+    libasound2 \
+    libfftw3-bin \
+    libgmp10 \
+    libgsl23 \
+    libgtk-3-0 \
+    libjack-jackd2-0 \
+    liblog4cpp5v5 \
+    libpangocairo-1.0-0 \
+    libportaudio2 \
+    libqwt-qt5-6 \
+    libsndfile1-dev \
+    libsdl-image1.2 \
+    libthrift-dev \
+    libuhd-dev \
+    libusb-1.0-0 \
+    libzmq5 \
+    libpango-1.0-0 \
+    gir1.2-gtk-3.0 \
+    gir1.2-pango-1.0 \
+    pkg-config \
+    thrift-compiler \
+    libunwind-dev \
+    build-essential \
+    ccache \
+    cmake \
+    libcppunit-dev \
+    libfftw3-dev \
+    libgmp-dev \
+    libgsl0-dev \
+    liblog4cpp5-dev \
+    libqwt-qt5-dev \
+    qtbase5-dev \
+    libsdl1.2-dev \
+    libuhd-dev \
+    libusb-1.0-0-dev \
+    libzmq3-dev \
+    portaudio19-dev \
+    pyqt5-dev-tools \
+    doxygen \
+    doxygen-latex \
+# Py3 deps
+    python3-click \
+    python3-click-plugins \
+    python3-dev \
+    python3-gi \
+    python3-gi-cairo \
+    python3-lxml \
+    python3-numpy \
+    python3-opengl \
+    python3-pyqt5 \
+    python3-yaml \
+    python3-zmq \
+    python3-six \
+    python3-pytest \
+# Testing deps
+    xvfb \
+    lcov \
+    python3-scipy \
+    --no-install-recommends \
+# backported Boost 1.71, spdlog, libfmt
+    && apt-get install -t buster-backports -qy \
+    libspdlog-dev \
+    libfmt-dev \
+    libboost1.71-all-dev \
+    && apt-get clean
+
+# Install Mako
+RUN DEBIAN_FRONTEND=noninteractive \
+    apt-get install -qy python3-pip \
+    --no-install-recommends \
+    && apt-get clean \
+    && pip3 install Mako
+
+# Install VOLK
+RUN mkdir -p /src/build && \
+    git clone --recursive https://github.com/gnuradio/volk.git /src/volk --branch v2.4.1 && \
+    cd /src/build && \
+    cmake -DCMAKE_BUILD_TYPE=Release ../volk/ && \
+    make && \
+    make install && \
+    cd / && \
+    rm -rf /src/
+
+# Install Pybind11
+RUN mkdir -p /src/build && \
+    git clone --recursive https://github.com/pybind/pybind11.git /src/pybind11 --branch v2.4.0 && \
+    cd /src/build && \
+    cmake -DPYBIND11_TEST=OFF /src/pybind11 && \
+    make install && \
+    rm -rf /src/
+
+# Install SoapySDR
+RUN mkdir -p /src \
+    && cd /src \
+    && git clone -b soapy-sdr-0.8.0 https://github.com/pothosware/SoapySDR/ \
+    && cd SoapySDR \
+    && mkdir build \
+    && cd build \
+    && cmake -DCMAKE_INSTALL_PREFIX=/usr .. \
+    && make install \
+    && cd / \
+    && rm -rf /src
+


### PR DESCRIPTION
This adds boost169-devel compared to the Centos 8.3 for 3.9 container.

This arose through https://github.com/gnuradio/gnuradio/pull/5278 ; can't build without Boost >= 1.69.