### PR TITLE
Add dependencies required for all tests to execute

### DIFF
--- a/ci/ci-debian-11-3.10/Dockerfile
+++ b/ci/ci-debian-11-3.10/Dockerfile
@@ -35,7 +35,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
     libunwind-dev \
     --no-install-recommends \
     && apt-get clean \
-    && apt-get autoclean 
+    && apt-get autoclean
 
 # Py3 deps
 RUN DEBIAN_FRONTEND=noninteractive \
@@ -74,10 +74,12 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libboost-system-dev \
     libboost-test-dev \
     libboost-thread-dev \
+    libcodec2-dev \
     libcppunit-dev \
     libfftw3-dev \
     libgmp-dev \
     libgsl0-dev \
+    libgsm1-dev \
     liblog4cpp5-dev \
     libqwt-qt5-dev \
     qtbase5-dev \
@@ -106,6 +108,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
 RUN apt-get -y install -q \
     git \
     ca-certificates \
+    appstream-util \
     --no-install-recommends && \
     apt-get clean && \
     apt-get autoclean

--- a/ci/ci-debian-i386-11-3.10/Dockerfile
+++ b/ci/ci-debian-i386-11-3.10/Dockerfile
@@ -35,7 +35,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
     libunwind-dev \
     --no-install-recommends \
     && apt-get clean \
-    && apt-get autoclean 
+    && apt-get autoclean
 
 # Py3 deps
 RUN DEBIAN_FRONTEND=noninteractive \
@@ -73,10 +73,12 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libboost-system-dev \
     libboost-test-dev \
     libboost-thread-dev \
+    libcodec2-dev \
     libcppunit-dev \
     libfftw3-dev \
     libgmp-dev \
     libgsl0-dev \
+    libgsm1-dev \
     liblog4cpp5-dev \
     libqwt-qt5-dev \
     qtbase5-dev \
@@ -105,6 +107,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
 RUN apt-get -y install -q \
     git \
     ca-certificates \
+    appstream-util \
     --no-install-recommends && \
     apt-get clean && \
     apt-get autoclean

--- a/ci/ci-fedora-35-3.9/Dockerfile
+++ b/ci/ci-fedora-35-3.9/Dockerfile
@@ -75,7 +75,7 @@ RUN dnf install --refresh -y \
 # For ccaching
         ccache \
 # For testing metainfo files
-        appstream \
+        libappstream-glib \
         && dnf clean all
 
 # Install VOLK

--- a/ci/ci-fedora-36-3.9/Dockerfile
+++ b/ci/ci-fedora-36-3.9/Dockerfile
@@ -75,7 +75,7 @@ RUN dnf install --refresh -y \
 # For ccaching
         ccache \
 # For testing metainfo files
-        appstream \
+        libappstream-glib \
 # Install VOLK
         volk-devel \
         && dnf clean all

--- a/ci/ci-ubuntu-20.04-3.9/Dockerfile
+++ b/ci/ci-ubuntu-20.04-3.9/Dockerfile
@@ -81,10 +81,12 @@ RUN mv /sbin/sysctl /sbin/sysctl.orig \
        libboost-system-dev \
        libboost-test-dev \
        libboost-thread-dev \
+       libcodec2-dev \
        libcppunit-dev \
        libfftw3-dev \
        libgmp-dev \
        libgsl0-dev \
+       libgsm1-dev \
        libiio-dev \
        libsoapysdr-dev \
        liblog4cpp5-dev \

--- a/ci/ci-ubuntu-22.04-3.9/Dockerfile
+++ b/ci/ci-ubuntu-22.04-3.9/Dockerfile
@@ -82,9 +82,11 @@ RUN mv /sbin/sysctl /sbin/sysctl.orig \
        libboost-system-dev \
        libboost-test-dev \
        libboost-thread-dev \
+       libcodec2-dev \
        libfftw3-dev \
        libgmp-dev \
        libgsl0-dev \
+       libgsm1-dev \
        libiio-dev \
        libsoapysdr-dev \
        libspdlog-dev \


### PR DESCRIPTION
Several tests fail to run on all CI platforms:

* `metainfo_test` fails to run on Fedora 35, Debian 11, and Debian 11 (32-bit)
  * On Fedora, the `appstream-util` command is provided by `libappstream-glib`, not `appstream`
  * On Debian, the `appstream-util` package is required
* `qa_codec2_vocoder` fails to run on ubuntu 20.04, 22.04, Debian 11, and Debian 11 (32-bit)
  * The `libcodec2-dev` package is required to build with Codec2 support
* `qa_gsm_full_rate` fails to run on ubuntu 20.04, 22.04, Debian 11, and Debian 11 (32-bit)
  * The `libgsm1-dev` package is required to build with GSM codec support

Here I've added the missing packages.