### PR TITLE
Add Fedora 37

### DIFF
--- a/.github/workflows/build-dockers.yml
+++ b/.github/workflows/build-dockers.yml
@@ -36,6 +36,8 @@ jobs:
             tag: fedora-35-3.9
           - path: ci/ci-fedora-36-3.9
             tag: fedora-36-3.9
+          - path: ci/ci-fedora-37-3.9
+            tag: fedora-37-3.9
           - path: ci/ci-ubuntu-18.04-3.8
             tag: ubuntu-18.04-3.8
           - path: ci/ci-ubuntu-18.04-3.9

--- a/ci/ci-fedora-37-3.9/Dockerfile
+++ b/ci/ci-fedora-37-3.9/Dockerfile
@@ -1,0 +1,86 @@
+FROM fedora:37
+LABEL maintainer="martin@gnuradio.org"
+
+ENV security_updates_as_of 2022-11-15
+
+# Build
+RUN dnf install --refresh -y \
+        cmake \
+        make \
+        gcc \
+        gcc-c++ \
+        xz \
+# CPP deps
+        asio-devel \
+        boost-devel \
+        log4cpp-devel \
+        cppzmq-devel \
+        spdlog-devel \
+        fmt-devel \
+# ctrlport - thrift
+        thrift \
+        thrift-devel \
+# Math libraries
+        fftw-devel \
+        gsl-devel \
+        gmp-devel \
+# Documentation
+        doxygen \
+        graphviz \
+# Audio, SDL
+        SDL-devel \
+        alsa-lib-devel \
+        portaudio-devel \
+        jack-audio-connection-kit-devel \
+        libsndfile-devel \
+# HW drivers
+        uhd-devel \
+## Vocoder libraries
+        codec2-devel \
+        gsm-devel \
+# gr-iio
+        libiio-devel \
+# gr-soapy
+        SoapySDR-devel \
+# Python deps
+        python3-devel \
+        python3-pybind11 \
+        python3-numpy \
+        python3-scipy \
+        python3-zmq \
+        python3-thrift \
+        python3-pytest \
+# GUI libraries
+        xdg-utils \
+        qwt-qt5-devel \
+        python3-qt5-devel \
+# XML Parsing / GRC
+        desktop-file-utils \
+        python3-mako \
+        python3-click \
+        python3-click-plugins \
+# GRC/next
+        python3-pyyaml \
+        python3-lxml \
+        python3-gobject \
+	      gtk3 \
+        python3-cairo \
+        pango \
+# Git For VOLK and libad9361 source building
+        git \
+# For ccaching
+        ccache \
+# For testing metainfo files
+        libappstream-glib \
+# Install VOLK
+        volk-devel \
+        && dnf clean all
+
+# Install libad9361
+RUN mkdir -p /src/build && \
+    git clone https://github.com/analogdevicesinc/libad9361-iio /src/libad9361 --branch v0.2 --depth 1 && \
+    cd /src/build && cmake -DCMAKE_BUILD_TYPE=Release ../libad9361/ && \
+    make && \
+    make install && \
+    cd / && \
+    rm -rf /src/


### PR DESCRIPTION
Fedora 37 was released today, and Fedora 35 will reach its end of life on December 13.

I've added a Fedora 37 container here. The only change I made vs. the Fedora 36 container was to remove the "clone3" workaround:

https://github.com/gnuradio/gnuradio-docker/blob/6da7dc819a921fd12d5f857ea36a67cfa9179c53/ci/ci-fedora-36-3.9/Dockerfile#L6-L8

I suspect this is no longer necessary, as long as GitHub Actions is using Docker 20.10.10 or later. If this works, we could remove the workaround from Fedora 36 as well.