### PR TITLE
Add OpenGL support for debian and ubuntu CI

### DIFF
--- a/ci/ci-debian-10-3.9/Dockerfile
+++ b/ci/ci-debian-10-3.9/Dockerfile
@@ -79,6 +79,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
        libgsl0-dev \
        liblog4cpp5-dev \
        libqwt-qt5-dev \
+       libqt5opengl5-dev \
        qtbase5-dev \
        libsdl1.2-dev \
        libuhd-dev \

--- a/ci/ci-debian-11-3.10/Dockerfile
+++ b/ci/ci-debian-11-3.10/Dockerfile
@@ -82,6 +82,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libgsm1-dev \
     liblog4cpp5-dev \
     libqwt-qt5-dev \
+    libqt5opengl5-dev \
     qtbase5-dev \
     libsdl1.2-dev \
     libuhd-dev \

--- a/ci/ci-debian-i386-11-3.10/Dockerfile
+++ b/ci/ci-debian-i386-11-3.10/Dockerfile
@@ -81,6 +81,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libgsm1-dev \
     liblog4cpp5-dev \
     libqwt-qt5-dev \
+    libqt5opengl5-dev \
     qtbase5-dev \
     libsdl1.2-dev \
     libuhd-dev \

--- a/ci/ci-ubuntu-18.04-3.9/Dockerfile
+++ b/ci/ci-ubuntu-18.04-3.9/Dockerfile
@@ -89,6 +89,7 @@ RUN mv /sbin/sysctl /sbin/sysctl.orig \
        libqwt-dev \
        libqwt5-qt4 \
        libqwt-qt5-dev \
+       libqt5opengl5-dev \
        qtbase5-dev \
        libsdl1.2-dev \
        libuhd-dev \

--- a/ci/ci-ubuntu-20.04-3.9/Dockerfile
+++ b/ci/ci-ubuntu-20.04-3.9/Dockerfile
@@ -93,6 +93,7 @@ RUN mv /sbin/sysctl /sbin/sysctl.orig \
        libspdlog-dev \
        libfmt-dev \
        libqwt-qt5-dev \
+       libqt5opengl5-dev \
        qtbase5-dev \
        libsdl1.2-dev \
        libuhd-dev \

--- a/ci/ci-ubuntu-22.04-3.9/Dockerfile
+++ b/ci/ci-ubuntu-22.04-3.9/Dockerfile
@@ -92,6 +92,7 @@ RUN mv /sbin/sysctl /sbin/sysctl.orig \
        libspdlog-dev \
        libfmt-dev \
        libqwt-qt5-dev \
+       libqt5opengl5-dev \
        qtbase5-dev \
        libsdl1.2-dev \
        libuhd-dev \


### PR DESCRIPTION
Adds support for OpenGL, so that the Fosphor Display block can build in CI

Fedora looks to already have support for building OpenGL