### PR TITLE
Fedora 40: add zsh for CI hash checking

### DIFF
--- a/ci/ci-fedora-40-3.10/Dockerfile
+++ b/ci/ci-fedora-40-3.10/Dockerfile
@@ -85,3 +85,7 @@ RUN mkdir -p /src/build && \
     make install && \
     cd / && \
     rm -rf /src/
+# Install zsh for hash checker CI
+# (Roll into large installation step above for next release)
+RUN dnf --refresh install -y zsh  &&\
+    dnf clean all


### PR DESCRIPTION
Fixes #49 