### PR TITLE
Fedora 41 builder

### DIFF
--- a/.github/workflows/build-dockers.yml
+++ b/.github/workflows/build-dockers.yml
@@ -28,14 +28,12 @@ jobs:
             tag: debian-i386-11-3.10
           - path: ci/ci-debian-12-3.10
             tag: debian-12-3.10
-          - path: ci/ci-fedora-37-3.9
-            tag: fedora-37-3.9
-          - path: ci/ci-fedora-38-3.10
-            tag: fedora-38-3.10
           - path: ci/ci-fedora-39-3.10
             tag: fedora-39-3.10
           - path: ci/ci-fedora-40-3.10
             tag: fedora-40-3.10
+          - path: ci/ci-fedora-41-3.10
+            tag: fedora-41-3.10
           - path: ci/ci-ubuntu-18.04-3.8
             tag: ubuntu-18.04-3.8
           - path: ci/ci-ubuntu-18.04-3.9

--- a/ci/ci-fedora-41-3.10/Dockerfile
+++ b/ci/ci-fedora-41-3.10/Dockerfile
@@ -1,0 +1,38 @@
+FROM fedora:41
+LABEL maintainer="mmueller@gnuradio.org"
+
+ENV security_updates_as_of 2025-01-23
+ARG LIBAD9361_TAG=v0.3
+ARG DNF_COMMAND="dnf --setopt=install_weak_deps=False"
+
+# Make sure we don't try to use XCB, which seems to be very b0rked at this point
+ENV QT_QPA_PLATFORM=offscreen
+
+# Build deps
+RUN ${DNF_COMMAND} build-dep --refresh -y gnuradio \
+        && ${DNF_COMMAND} install -y \
+        # gr-iio
+        libiio-devel \
+        # JSON/YAML runtime config GRC blocks
+        python3-jsonschema \
+        # doxygen build (we should fix that with fedora's packaging)
+        texlive-newunicodechar \
+        && ${DNF_COMMAND} clean all
+# Specific tools not needed for the default build, but things we want to do in CI:
+RUN ${DNF_COMMAND} install --refresh -y \
+        clang \
+        clang-tools-extra \
+        ninja-build \
+        # For testing metainfo files
+        libappstream-glib \
+        # Install zsh for hash checker CI
+        zsh \
+        # For hash checking and libad9361 building
+        git \
+        && ${DNF_COMMAND} clean all
+# Install libad9361
+RUN mkdir -p /src/build \
+        && git clone https://github.com/analogdevicesinc/libad9361-iio /src/libad9361 --branch ${LIBAD9361_TAG} --depth 1 \
+        && cd /src/build && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ../libad9361/ \
+        && make && make install \
+        && cd / && rm -rf /src


### PR DESCRIPTION
Do fewer fancy things: instead, track distro packaging dependencies,
which ensures we're building with the tools the distro packager does,
too.

Fix the issue that Qt's xcb backend seems to fail and hence gr-qtgui's
QA can't run.

Add missing latex dependency (need to work with packaging upstream on
that one).

Layer more sensibly.

Signed-off-by: Marcus Müller <marcus@hostalia.de>
