### PR TITLE
blocks: Add `nlohmann/json` as a dependency to CI runner containers

### DIFF
--- a/ci/ci-debian-12-3.10/Dockerfile
+++ b/ci/ci-debian-12-3.10/Dockerfile
@@ -107,6 +107,7 @@ RUN \
     libvolk2-dev \
     libzmq3-dev \
     libzmq5 \
+    nlohmann-json3-dev \
     portaudio19-dev \
     pyqt5-dev-tools \
     qtbase5-dev \

--- a/ci/ci-debian-13-3.10/Dockerfile
+++ b/ci/ci-debian-13-3.10/Dockerfile
@@ -106,6 +106,7 @@ RUN \
     libvolk-dev \
     libzmq3-dev \
     libzmq5 \
+    nlohmann-json3-dev \
     portaudio19-dev \
     pyqt5-dev-tools \
     qtbase5-dev \

--- a/ci/ci-debian-i386-12-3.10/Dockerfile
+++ b/ci/ci-debian-i386-12-3.10/Dockerfile
@@ -106,6 +106,7 @@ RUN \
     libvolk2-dev \
     libzmq3-dev \
     libzmq5 \
+    nlohmann-json3-dev \
     portaudio19-dev \
     pyqt5-dev-tools \
     qtbase5-dev \

--- a/ci/ci-fedora-42-3.10/Dockerfile
+++ b/ci/ci-fedora-42-3.10/Dockerfile
@@ -71,6 +71,7 @@ RUN ${DNF_COMMAND} build-dep --refresh -y gnuradio \
         && ${DNF_COMMAND} install -y \
         # gr-iio
         libiio-devel \
+        nlohmann-json3-dev \
         # JSON/YAML runtime config GRC blocks
         python3-jsonschema \
         # doxygen build (we should fix that with fedora's packaging)

--- a/ci/ci-fedora-42-3.10/Dockerfile
+++ b/ci/ci-fedora-42-3.10/Dockerfile
@@ -71,7 +71,7 @@ RUN ${DNF_COMMAND} build-dep --refresh -y gnuradio \
         && ${DNF_COMMAND} install -y \
         # gr-iio
         libiio-devel \
-        nlohmann-json3-dev \
+        json-devel \
         # JSON/YAML runtime config GRC blocks
         python3-jsonschema \
         # doxygen build (we should fix that with fedora's packaging)

--- a/ci/ci-fedora-43-3.10/Dockerfile
+++ b/ci/ci-fedora-43-3.10/Dockerfile
@@ -73,6 +73,7 @@ RUN ${DNF_COMMAND} build-dep --refresh -y gnuradio \
         && ${DNF_COMMAND} install -y \
         # gr-iio
         libiio-devel \
+        nlohmann-json3-dev \
         # JSON/YAML runtime config GRC blocks
         python3-jsonschema \
         # doxygen build (we should fix that with fedora's packaging)

--- a/ci/ci-fedora-43-3.10/Dockerfile
+++ b/ci/ci-fedora-43-3.10/Dockerfile
@@ -73,7 +73,7 @@ RUN ${DNF_COMMAND} build-dep --refresh -y gnuradio \
         && ${DNF_COMMAND} install -y \
         # gr-iio
         libiio-devel \
-        nlohmann-json3-dev \
+        json-devel \
         # JSON/YAML runtime config GRC blocks
         python3-jsonschema \
         # doxygen build (we should fix that with fedora's packaging)

--- a/ci/ci-ubuntu-22.04-3.9/Dockerfile
+++ b/ci/ci-ubuntu-22.04-3.9/Dockerfile
@@ -66,6 +66,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
          libpango-1.0-0 \
          gir1.2-gtk-3.0 \
          gir1.2-pango-1.0 \
+         nlohmann-json3-dev \
          pkg-config \
          thrift-compiler \
          libvolk2-dev \

--- a/ci/ci-ubuntu-24.04-3.10/Dockerfile
+++ b/ci/ci-ubuntu-24.04-3.10/Dockerfile
@@ -48,12 +48,12 @@ RUN \
   cmake \
   git \
   lcov \
+  nlohmann-json3-dev \
   pkg-config \
   xvfb \
   # for bundling up results
   squashfs-tools \
-  && apt-get build-dep -qy gnuradio \
-  && apt-get clean && apt-get autoclean
+  && apt-get build-dep -qy gnuradio \  && apt-get clean && apt-get autoclean
 
 # Copy over sccache
 COPY --from=sccache-builder /target/bin/sccache /usr/bin/sccache

--- a/ci/ci-ubuntu-24.04-3.10/Dockerfile
+++ b/ci/ci-ubuntu-24.04-3.10/Dockerfile
@@ -53,7 +53,8 @@ RUN \
   xvfb \
   # for bundling up results
   squashfs-tools \
-  && apt-get build-dep -qy gnuradio \  && apt-get clean && apt-get autoclean
+  && apt-get build-dep -qy gnuradio \
+  && apt-get clean && apt-get autoclean
 
 # Copy over sccache
 COPY --from=sccache-builder /target/bin/sccache /usr/bin/sccache


### PR DESCRIPTION
The CI checks for [#8109](https://github.com/gnuradio/gnuradio/pull/8109) in GNU Radio are failing because [`nlohmann/json`](github.com/nlohmann/json) is not available inside the GitHub Actions runner's containers. In each case, the job runs tests that fail citing `ImportError: cannot import name 'blocks' from 'gnuradio'` because the `gr-blocks` component is being disabled.

To address this, I am introducing this third party library dependency to the images used by GNU Radio's CI. Initially, I've scoped this only to images that are being used by the CI checks in the PR.

Some of the `Dockerfile`'s install the dependencies from the distro's packaged version, like [here](https://github.com/gnuradio/gnuradio-docker/blob/master/ci/ci-ubuntu-24.04-3.10/Dockerfile#L55). I don't have control over this, so I've a little hamfistedly just installed it explicitly.

I have successfully built images on my machine using each of the updated `Dockerfile`'s.