### PR TITLE
Add builders for GR4 (rerun on gnuradio account CI)

### DIFF
--- a/.github/workflows/build-dockers.yml
+++ b/.github/workflows/build-dockers.yml
@@ -32,6 +32,12 @@ jobs:
             tag: fedora-42-3.10
           - path: ci/ci-fedora-43-3.10
             tag: fedora-43-3.10
+          - path: ci/ci-fedora-44-4.0
+            tag: fedora-44-4.0
+          - path: ci/ci-ubuntu-24.04-4.0
+            tag: ubuntu-24.04-4.0
+          - path: ci/ci-ubuntu-24.04-4.0-emscripten
+            tag: ubuntu-24.04-4.0-emscripten
           - path: ci/ci-ubuntu-20.04-3.9
             tag: ubuntu-20.04-3.9
           - path: ci/ci-ubuntu-22.04-3.9

--- a/ci/ci-fedora-44-4.0/Dockerfile
+++ b/ci/ci-fedora-44-4.0/Dockerfile
@@ -1,0 +1,54 @@
+ARG FEDORA_VERSION=44
+ARG DNF_COMMAND="dnf --setopt=install_weak_deps=False -q"
+
+
+FROM fedora:${FEDORA_VERSION}
+ARG DNF_COMMAND
+
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    PKG_CONFIG=pkg-config \
+    CC=clang \
+    CXX=clang++
+
+RUN ${DNF_COMMAND} update -y \
+    && ${DNF_COMMAND} install -y \
+        bash \
+        ccache \
+        ca-certificates \
+        cmake \
+        file \
+        findutils \
+        gcc \
+        gcc-c++ \
+        git \
+        gnupg2 \
+        lsb_release \
+        make \
+        ninja-build \
+        pkgconf-pkg-config \
+        python3 \
+        python3-devel \
+        python3-numpy \
+        pybind11-devel \
+        wget \
+        cppzmq-devel \
+        boost-devel \
+        brotli-devel \
+        libcurl-devel \
+        cpp-httplib-devel \
+        fftw-devel \
+        gtest-devel \
+        openssl-devel \
+        tbb-devel \
+        json-devel \
+        cli11-devel \
+        rtaudio-devel \
+        portaudio-devel \
+        SoapySDR-devel \
+        clang \
+        compiler-rt \
+        libcxx-devel \
+        libcxxabi-devel \
+        libunwind-devel \
+    && ${DNF_COMMAND} clean all

--- a/ci/ci-ubuntu-24.04-4.0-emscripten/Dockerfile
+++ b/ci/ci-ubuntu-24.04-4.0-emscripten/Dockerfile
@@ -1,0 +1,56 @@
+ARG UBUNTU_VERSION=24.04
+ARG APT_INSTALL_COMMAND="apt-get install -qy --no-install-recommends"
+ARG EMSDK_VERSION=5.0.2
+
+
+FROM ubuntu:${UBUNTU_VERSION}
+ARG APT_INSTALL_COMMAND
+ARG EMSDK_VERSION
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    EMSDK_HOME=/opt/emsdk \
+    EMSDK_VERSION=${EMSDK_VERSION} \
+    CMAKE_MAKE_PROGRAM=ninja \
+    CCACHE_DIR=/tmp/ccache \
+    NODE_PATH=/usr/local/lib/node_modules \
+    CC=emcc \
+    CXX=em++ \
+    PATH=/opt/emsdk:/opt/emsdk/upstream/emscripten:${PATH}
+
+RUN apt-get update -q \
+    && apt-get -y upgrade \
+    && ${APT_INSTALL_COMMAND} \
+        bash \
+        bzip2 \
+        ca-certificates \
+        ccache \
+        cmake \
+        file \
+        g++-14 \
+        gcc-14 \
+        git \
+        make \
+        ninja-build \
+        nodejs \
+        npm \
+        python3 \
+        xz-utils \
+    && apt-get clean \
+    && apt-get autoclean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p ${EMSDK_HOME} \
+    && git clone --depth 1 https://github.com/emscripten-core/emsdk.git ${EMSDK_HOME} \
+    && ${EMSDK_HOME}/emsdk install ${EMSDK_VERSION} \
+    && ${EMSDK_HOME}/emsdk activate ${EMSDK_VERSION} \
+    && npm install --ignore-scripts -g xhr2 \
+    && . ${EMSDK_HOME}/emsdk_env.sh \
+    && embuilder build sdl3 \
+    && chmod -R a+rwX ${EMSDK_HOME}
+
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 140 \
+        --slave /usr/bin/g++ g++ /usr/bin/g++-14 \
+        --slave /usr/bin/gcov gcov /usr/bin/gcov-14 \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-14 140

--- a/ci/ci-ubuntu-24.04-4.0/Dockerfile
+++ b/ci/ci-ubuntu-24.04-4.0/Dockerfile
@@ -1,0 +1,84 @@
+ARG UBUNTU_VERSION=24.04
+ARG APT_INSTALL_COMMAND="apt-get install -qy --no-install-recommends"
+
+
+FROM ubuntu:${UBUNTU_VERSION}
+ARG APT_INSTALL_COMMAND
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    PKG_CONFIG=pkg-config \
+    CC=gcc-14 \
+    CXX=g++-14
+
+RUN apt-get update -q \
+    && apt-get -y upgrade \
+    && ${APT_INSTALL_COMMAND} \
+        bash \
+        build-essential \
+        ca-certificates \
+        ccache \
+        cmake \
+        file \
+        git \
+        gpg \
+        lsb-release \
+        locales \
+        make \
+        ninja-build \
+        pkg-config \
+        software-properties-common \
+        wget \
+    && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+    && install -d -m 0755 /etc/apt/keyrings \
+    && wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/keyrings/llvm.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/llvm.gpg] https://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" > /etc/apt/sources.list.d/llvm20.list \
+    && apt-get update -q \
+    && ${APT_INSTALL_COMMAND} \
+        cppzmq-dev \
+        libboost-system-dev \
+        libbrotli-dev \
+        libcurl4-openssl-dev \
+        libcpp-httplib-dev \
+        libfftw3-dev \
+        libgtest-dev \
+        libssl-dev \
+        libtbb-dev \
+        nlohmann-json3-dev \
+        python3 \
+        python3-dev \
+        python3-numpy \
+        pybind11-dev \
+        libcli11-dev \
+        librtaudio-dev \
+        libportaudio2 \
+        libsoapysdr-dev \
+        soapysdr-module-hackrf \
+        soapysdr-tools \
+        gcc-14 \
+        g++-14 \
+        libstdc++-14-dev \
+        gcc-15 \
+        g++-15 \
+        libstdc++-15-dev \
+        clang-20 \
+        libclang-rt-20-dev \
+        libc++-20-dev \
+        libc++abi-20-dev \
+        libunwind-20-dev \
+    && apt-get clean \
+    && apt-get autoclean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 140 \
+        --slave /usr/bin/g++ g++ /usr/bin/g++-14 \
+        --slave /usr/bin/gcov gcov /usr/bin/gcov-14 \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-15 150 \
+        --slave /usr/bin/g++ g++ /usr/bin/g++-15 \
+        --slave /usr/bin/gcov gcov /usr/bin/gcov-15 \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-14 140 \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-15 150 \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-20 120 \
+    && update-alternatives --set gcc /usr/bin/gcc-14 \
+    && update-alternatives --set c++ /usr/bin/g++-14


### PR DESCRIPTION
This is just #69, run on our own CI.

It seems that I mistakenly set things up such that PR CI fails if not run from the gnuradio/gnuradio-docker repo. I need to fix that.
