### PR TITLE
Add libsoundio, cpr, vir-simd, boost-ut into build images

### DIFF
--- a/ci/ci-fedora-44-4.0/Dockerfile
+++ b/ci/ci-fedora-44-4.0/Dockerfile
@@ -36,11 +36,14 @@ RUN ${DNF_COMMAND} update -y \
         boost-devel \
         brotli-devel \
         libcurl-devel \
+        cpr-devel \
         cpp-httplib-devel \
         fftw-devel \
         gtest-devel \
+        libsoundio-devel \
         openssl-devel \
         tbb-devel \
+        ut-devel \
         json-devel \
         cli11-devel \
         rtaudio-devel \
@@ -52,3 +55,8 @@ RUN ${DNF_COMMAND} update -y \
         libcxxabi-devel \
         libunwind-devel \
     && ${DNF_COMMAND} clean all
+
+RUN git clone --branch v0.4.4 --depth 1 https://github.com/mattkretz/vir-simd.git /opt/vir-simd \
+    && cmake -E copy_directory /opt/vir-simd/vir /usr/local/include/vir \
+    && rm -rf /opt/vir-simd
+    

--- a/ci/ci-ubuntu-24.04-4.0/Dockerfile
+++ b/ci/ci-ubuntu-24.04-4.0/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get update -q \
         libcpp-httplib-dev \
         libfftw3-dev \
         libgtest-dev \
+        libsoundio-dev \
         libssl-dev \
         libtbb-dev \
         nlohmann-json3-dev \
@@ -82,3 +83,26 @@ RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 140 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-20 120 \
     && update-alternatives --set gcc /usr/bin/gcc-14 \
     && update-alternatives --set c++ /usr/bin/g++-14
+
+RUN git clone --branch 1.14.1 --depth 1 https://github.com/libcpr/cpr.git /tmp/cpr \
+    && cmake -S /tmp/cpr -B /tmp/cpr/build -G Ninja \
+        -DCPR_USE_SYSTEM_CURL=ON \
+        -DCPR_BUILD_TESTS=OFF \
+        -DCPR_BUILD_TESTS_SSL=OFF \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCMAKE_BUILD_TYPE=Release \
+    && cmake --build /tmp/cpr/build \
+    && cmake --install /tmp/cpr/build \
+    && rm -rf /tmp/cpr
+
+RUN git clone https://github.com/boost-ext/ut.git /tmp/ut \
+    && git -C /tmp/ut checkout 53e17f25119598c6458d30351b260193096ba67e \
+    && cmake -S /tmp/ut -B /tmp/ut/build -G Ninja \
+        -DBOOST_UT_DISABLE_MODULE=ON \
+        -DCMAKE_BUILD_TYPE=Release \
+    && cmake --install /tmp/ut/build \
+    && rm -rf /tmp/ut
+
+RUN git clone --branch v0.4.4 --depth 1 https://github.com/mattkretz/vir-simd.git /opt/vir-simd \
+    && cmake -E copy_directory /opt/vir-simd/vir /usr/local/include/vir \
+    && rm -rf /opt/vir-simd

--- a/ci/ci-ubuntu-26.04-4.0/Dockerfile
+++ b/ci/ci-ubuntu-26.04-4.0/Dockerfile
@@ -31,9 +31,12 @@ RUN apt-get update -q \
         libboost-system-dev \
         libbrotli-dev \
         libcurl4-openssl-dev \
+        libboost-ext-ut-dev \
         libcpp-httplib-dev \
+        libcpr-dev \
         libfftw3-dev \
         libgtest-dev \
+        libsoundio-dev \
         libssl-dev \
         libtbb-dev \
         nlohmann-json3-dev \
@@ -57,3 +60,7 @@ RUN apt-get update -q \
     && apt-get clean \
     && apt-get autoclean \
     && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 --branch v0.4.4 https://github.com/mattkretz/vir-simd.git /opt/vir-simd \
+    && cmake -E copy_directory /opt/vir-simd/vir /usr/local/include/vir \
+    && rm -rf /opt/vir-simd


### PR DESCRIPTION
To be able to remove FetchContent in gnuradio4 build process, we need these deps in the CI build images.

