### PR TITLE
ubuntu 24.04-4.0: install gcovr, as used in GCC-14 coverage CI

### DIFF
--- a/ci/ci-ubuntu-24.04-4.0/Dockerfile
+++ b/ci/ci-ubuntu-24.04-4.0/Dockerfile
@@ -129,5 +129,13 @@ RUN git clone --branch v0.4.4 --depth 1 https://github.com/mattkretz/vir-simd.gi
     && cmake -E copy_directory /opt/vir-simd/vir /usr/local/include/vir \
     && rm -rf /opt/vir-simd
 
+# Install gcovr for coverage tests
+RUN apt-get update -q \
+    && ${APT_INSTALL_COMMAND} \
+    gcovr \
+    && apt-get clean \
+    && apt-get autoclean \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy over sccache
 COPY --from=sccache-builder /target/bin/sccache /usr/bin/sccache


### PR DESCRIPTION
We have periodic coverage testing, and it fails because gcovr is missing:
https://github.com/gnuradio/gnuradio4/actions/runs/26687028140/job/78656895485

let's fix that!

